### PR TITLE
Change the way to read the consumed capacity

### DIFF
--- a/src/CapacityCalculator.js
+++ b/src/CapacityCalculator.js
@@ -30,7 +30,7 @@ export default class CapacityCalculator extends CapacityCalculatorBase {
     // Default algorithm for projecting a good value for the current ConsumedThroughput is:
     // 1. Query 5 average readings each spanning a minute
     // 2. Select the Max value from those 5 readings
-    let averages = data.Datapoints.map(dp => dp.Average);
+    let averages = data.Datapoints.map(dp => dp.Sum / data.period);
     return Math.max(...averages);
   }
 }

--- a/src/capacity/CapacityCalculatorBase.js
+++ b/src/capacity/CapacityCalculatorBase.js
@@ -103,25 +103,27 @@ export default class CapacityCalculatorBase {
       // These values determine how many minutes worth of metrics
       let statisticCount = 5;
       let statisticSpanMinutes = 1;
-      let statisticType = 'Average';
+      let statisticType = 'Sum';
 
       let EndTime = new Date();
       let StartTime = new Date();
       StartTime.setTime(EndTime - (60000 * statisticSpanMinutes * statisticCount));
       let MetricName = isRead ? 'ConsumedReadCapacityUnits' : 'ConsumedWriteCapacityUnits';
       let Dimensions = this.getDimensions(tableName, globalSecondaryIndexName);
+      let period = (statisticSpanMinutes * 60);
       let params = {
         Namespace: 'AWS/DynamoDB',
         MetricName,
         Dimensions,
         StartTime,
         EndTime,
-        Period: (statisticSpanMinutes * 60),
+        Period: period,
         Statistics: [ statisticType ],
         Unit: 'Count'
       };
 
       let statistics = await this.cw.getMetricStatisticsAsync(params);
+      statistics.period = period;
       let value = this.getProjectedValue(statistics);
       let result: ConsumedCapacityDesc = {
         tableName,


### PR DESCRIPTION
- Now uses the sum and then divides it by the period which gives us an accurate consumed capacity

This is my proposed solution for https://github.com/channl/dynamodb-lambda-autoscale/issues/15 

@tmitchel2 - let me know if you want me to do anything else. 
