### PR TITLE
Support for DynamoDB with >100 tables

### DIFF
--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -20,8 +20,20 @@ export default class Provisioner extends ProvisionerConfigurableBase {
   async getTableNamesAsync(): Promise<string[]> {
 
     // Option 1 - All tables (Default)
+    //   The output from ListTables is paginated, with each page
+    //   returning a maximum of 100 table names.
     let listTablesResponse = await this.db.listTablesAsync();
-    return listTablesResponse.TableNames;
+    var tableNames = listTablesResponse.TableNames;
+    var lastTable = listTablesResponse.LastEvaluatedTableName;
+
+    while (lastTable) {
+      var params = { ExclusiveStartTableName: lastTable };
+      let listTablesResponse = await this.db.listTablesAsync(params);
+      tableNames = tableNames.concat(listTablesResponse.TableNames);
+      lastTable = listTablesResponse.LastEvaluatedTableName;
+    }
+
+    return tableNames;
 
     // Option 2 - Hardcoded list of tables
     // return ['Table1', 'Table2', 'Table3'];


### PR DESCRIPTION
This pull request adds support for DynamoDBs with >100 tables.

> The output from ListTables is paginated, with each page returning a maximum of 100 table names.
> 
> **Source:** http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html
