### PR TITLE
Add throttle metrics to describeTableConsumedCapacityAsync

### DIFF
--- a/src/flow/FlowTypes.js
+++ b/src/flow/FlowTypes.js
@@ -1,11 +1,17 @@
 /* @flow */
 import type { ProvisionedThroughput, Throughput } from 'aws-sdk-promise';
 
+export type ThrottledEventsDescription = {
+  ThrottledReadEvents: number,
+  ThrottledWriteEvents: number
+}
+
 export type TableProvisionedAndConsumedThroughput = {
   TableName: string,
   IndexName?: string,
   ProvisionedThroughput: ProvisionedThroughput,
   ConsumedThroughput: Throughput,
+  ThrottledEvents: ThrottledEventsDescription
 };
 
 export type GlobalSecondaryIndexConsumedThroughput = {
@@ -17,6 +23,7 @@ export type TableConsumedCapacityDescription = {
   TableName: string,
   ConsumedThroughput: Throughput,
   GlobalSecondaryIndexes: GlobalSecondaryIndexConsumedThroughput[],
+  ThrottledEvents: ThrottledEventsDescription
 };
 
 export type ConsumedCapacityDesc = {

--- a/src/provisioning/ProvisionerConfigurableBase.js
+++ b/src/provisioning/ProvisionerConfigurableBase.js
@@ -70,7 +70,8 @@ export default class ProvisionerConfigurableBase extends ProvisionerBase {
       let tableData = {
         TableName: tableDescription.TableName,
         ProvisionedThroughput: tableDescription.ProvisionedThroughput,
-        ConsumedThroughput: tableConsumedCapacityDescription.ConsumedThroughput
+        ConsumedThroughput: tableConsumedCapacityDescription.ConsumedThroughput,
+        ThrottledEvents: tableConsumedCapacityDescription.ThrottledEvents
       };
 
       let provisionedThroughput = this.getUpdatedProvisionedThroughput(tableData);
@@ -177,7 +178,8 @@ export default class ProvisionerConfigurableBase extends ProvisionerBase {
         TableName: tableDescription.TableName,
         IndexName: gsicc.IndexName,
         ProvisionedThroughput: gsi.ProvisionedThroughput,
-        ConsumedThroughput: gsicc.ConsumedThroughput
+        ConsumedThroughput: gsicc.ConsumedThroughput,
+        ThrottledEvents: gsicc.ThrottledEvents
       });
 
       // eslint-disable-next-line eqeqeq


### PR DESCRIPTION
From Amazon: "It is possible to have short spikes in consumed [READ/WRITE] capacity which do not show up [because] it is an average. So be careful when adjusting table [READ/WRITE] capacity to pay attention to the Throttled [READ/WRITE] Requests..."

Had a use-case for this type of functionality in my production system. Figured it would be useful for others and wanted to give back. Thanks for the awesome package! 
