### PR TITLE
Adding region & table(s) envvar overrides

### DIFF
--- a/src/CapacityCalculator.js
+++ b/src/CapacityCalculator.js
@@ -9,7 +9,7 @@ export default class CapacityCalculator extends CapacityCalculatorBase {
 
   // Get the region
   getCloudWatchRegion() {
-    return Region;
+    return process.env.DDB_AUTOSCALE_REGION || Region;
   }
 
   getStatisticSettings(): StatisticSettings {

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -13,19 +13,23 @@ export default class Provisioner extends ProvisionerConfigurableBase {
 
   // Get the region
   getDynamoDBRegion(): string {
-    return Region;
+    return process.env.DDB_AUTOSCALE_REGION || Region;
   }
 
   // Gets the list of tables which we want to autoscale
   async getTableNamesAsync(): Promise<string[]> {
+    // Option 1 - Tables defined by an environment variable if defined
+    if ('DDB_AUTOSCALE_TABLES' in process.env && typeof process.env.DDB_AUTOSCALE_TABLES === 'string') {
+      return process.env.DDB_AUTOSCALE_TABLES.split(',');
+    }
 
-    // Option 1 - All tables (Default)
+    // Option 2 - All tables (Default)
     return await this.db.listAllTableNamesAsync();
 
-    // Option 2 - Hardcoded list of tables
+    // Option 3 - Hardcoded list of tables
     // return ['Table1', 'Table2', 'Table3'];
 
-    // Option 3 - DynamoDB / S3 configured list of tables
+    // Option 4 - DynamoDB / S3 configured list of tables
     // return await ...;
   }
 


### PR DESCRIPTION
I was tracking the discussion in #27 and took a crack at starting to allow for lambda environment overrides.  Region & table subset support was pretty easy, but the configuration files around scaling strategies are pretty verbose.  Not sure yet about the best possibilities here, but it might make sense to have a simpler strategy that takes some solid guesses but limits the amount of config decisions to make.  Figured this was straightforward enough as a start and happy to put more work in / have a conversation around where you'd like to see this go 😄 