### PR TITLE
Add an environment provisioner that allows to specify environment variables to tweak the configuration

### DIFF
--- a/src/EnvironmentProvisioner.js
+++ b/src/EnvironmentProvisioner.js
@@ -1,0 +1,66 @@
+import DefaultProvisioner from './configuration/DefaultProvisioner';
+
+/*
+ * Go through the given JSON object and replace values using environment
+ * variables if available. The environment variables follow the scheme of
+ * the names in the JSON. For instance, the following JSON scheme will be
+ * populated with the environment variables whose names are the given values:
+ *
+ * {
+ *   "ReadCapacity": {
+ *     "Min": READCAPACITY_MIN,
+ *     "Max": READCAPACITY_MAX,
+ *     "Increment": {
+ *       "When": {
+ *         "UtilisationIsAbovePercent": READCAPACITY_INCREMENT_WHEN_UTILISATIONISABOVEPERCENT,
+ *         "ThrottledEventsPerMinuteIsAbove": READCAPACITY_INCREMENT_WHEN_THROTTLEDEVENTSPERMINUTEISABOVE
+ *       },
+ *     }
+ *  }
+ */
+function populateJson(json, prefixEnv=false, list_available=false) {
+  var ret = {}
+
+  if (prefixEnv) {
+    prefixEnv = prefixEnv + '_'
+  } else {
+    prefixEnv = ''
+  }
+
+  for (var key in json) {
+    env = (prefixEnv + key).toUpperCase()
+    if (typeof json[key] == 'object') {
+      if (list_available) {
+        Object.assign(ret, populateJson(json[key], env, list_available));
+      } else {
+        ret[key] = populateJson(json[key], env, list_available)
+      }
+    } else {
+      if (list_available) {
+        ret[env] = json[key]
+      } else {
+        if (typeof process.env[env] === 'undefined'
+              || isNaN(process.env[env]) != isNaN(json[key])) {
+          ret[key] = json[key]
+        } else if (isNaN(process.env[env])) {
+          ret[key] = process.env[env]
+        } else {
+          ret[key] = Number(process.env[env])
+        }
+      }
+    }
+  }
+
+  return ret
+}
+
+if (typeof process.env['ENVIRONMENTPROVISIONER_LIST_AVAILABLE'] !== 'undefined' &&
+      process.env['ENVIRONMENTPROVISIONER_LIST_AVAILABLE'] == 'true') {
+    console.log('%j', populateJson(DefaultProvisioner, false, true))
+    process.exit(0)
+}
+
+/*
+ * Use the DefaultProvisioner as basis for the EnvironmentProvisioner
+ */
+module.exports = populateJson(DefaultProvisioner)

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -8,6 +8,7 @@ import { Region } from './configuration/Region';
 import DefaultProvisioner from './configuration/DefaultProvisioner';
 import { invariant } from './Global';
 import type { TableProvisionedAndConsumedThroughput, ProvisionerConfig, AdjustmentContext } from './flow/FlowTypes';
+import EnvironmentProvisioner from './EnvironmentProvisioner';
 
 export default class Provisioner extends ProvisionerConfigurableBase {
 
@@ -34,7 +35,7 @@ export default class Provisioner extends ProvisionerConfigurableBase {
   getTableConfig(data: TableProvisionedAndConsumedThroughput): ProvisionerConfig {
 
     // Option 1 - Default settings for all tables
-    return DefaultProvisioner;
+    return EnvironmentProvisioner;
 
     // Option 2 - Bespoke table specific settings
     // return data.TableName === 'Table1' ? Climbing : Default;


### PR DESCRIPTION
This allows to use the DefaultProvisioner as default configuration, while being able to change some of the configuration using environment variables.

Signed-off-by: Raphaël Beamonte <raphael.beamonte@gmail.com>