### PR TITLE
Add env var table assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ configuration.  Please see the respective websites for advantages / reasons.
 The default setup in the [Provisioner.js](./src/Provisioner.js) allows for a quick no touch setup.
 A breakdown of the configuration behaviour is as follows:
 - AWS region is set to 'us-east-1' via [Region.json](./src/configuration/Region.json) configuration
-- Autoscales all tables and indexes
+- Configure Tables to scale:
+  - If you wish to autoscale only some tables in your account, create an environment variable `TABLE_NAMES` with comma separated list of table names
+    - All secondary indexes of these tables will also be autoscaled
+  - Exclude `TABLE_NAMES` to autoscale all tables and indexes
 - Autoscaling 'Strategy' settings are defined in [DefaultProvisioner.json](./src/configuration/DefaultProvisioner.json) and are as follows
   - Separate 'Read' and 'Write' capacity adjustment strategies
   - Separate asymmetric 'Increment' and 'Decrement' capacity adjustment strategies

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -21,10 +21,10 @@ export default class Provisioner extends ProvisionerConfigurableBase {
 
     // Option 1
     // User may pass in comma separated list of tables as ENV VAR 'TABLE_NAMES' to describe tables to manage, or leave it blank to manage all tables
-    if (process.env.TABLE_NAME != null) {
+    if (process.env.TABLE_NAMES != null) {
       return process.env.TABLE_NAMES.replace(/ /g,'').split(",");
     } else {
-      return this.db.listAllTableNamesAsync();
+      return await this.db.listAllTableNamesAsync();
     }
 
     // Option 2 - DynamoDB / S3 configured list of tables

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -19,13 +19,15 @@ export default class Provisioner extends ProvisionerConfigurableBase {
   // Gets the list of tables which we want to autoscale
   async getTableNamesAsync(): Promise<string[]> {
 
-    // Option 1 - All tables (Default)
-    return await this.db.listAllTableNamesAsync();
+    // Option 1
+    // User may pass in comma separated list of tables as ENV VAR 'TABLE_NAMES' to describe tables to manage, or leave it blank to manage all tables
+    if (process.env.TABLE_NAME != null) {
+      return process.env.TABLE_NAMES.replace(/ /g,'').split(",");
+    } else {
+      return this.db.listAllTableNamesAsync();
+    }
 
-    // Option 2 - Hardcoded list of tables
-    // return ['Table1', 'Table2', 'Table3'];
-
-    // Option 3 - DynamoDB / S3 configured list of tables
+    // Option 2 - DynamoDB / S3 configured list of tables
     // return await ...;
   }
 


### PR DESCRIPTION
Quick and dirty change that allows for specifying tables to autoscale while leaving previous functionality in place.  The use of environment vars allows users to configure via AWS console or CLI without modifying and redeploying the dynamodb-lambda-autoscale package.