### PR TITLE
Fixes for southeast deployment (caveat Region.json needs editing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ configuration.  Please see the respective websites for advantages / reasons.
 
 The default setup in the [Provisioner.js](./src/Provisioner.js) allows for a quick no touch setup.
 A breakdown of the configuration behaviour is as follows:
-- AWS region is set to 'us-east-1' via [Region.json](./src/configuration/Region.json) configuration
+- AWS region is set to 'ap-southeast-2' via [Region.json](./src/configuration/Region.json) configuration
 - Autoscales all tables and indexes
 - Autoscaling 'Strategy' settings are defined in [DefaultProvisioner.json](./src/configuration/DefaultProvisioner.json) and are as follows
   - Separate 'Read' and 'Write' capacity adjustment strategies

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,56 +52,6 @@ gulp.task('zip', function() {
     .pipe(gulp.dest('./'));
 });
 
-// Per the gulp guidelines, we do not need a plugin for something that can be
-// done easily with an existing node module. #CodeOverConfig
-//
-// Note: This presumes that AWS.config already has credentials. This will be
-// the case if you have installed and configured the AWS CLI.
-//
-// See http://aws.amazon.com/sdk-for-node-js/
-gulp.task('upload', function() {
-
-  // TODO: This should probably pull from package.json
-  AWS.config.region = 'us-east-1';
-  var lambda = new AWS.Lambda();
-  var functionName = 'video-events';
-
-  lambda.getFunction({FunctionName: functionName}, function(err, data) {
-    if (err) {
-      if (err.statusCode === 404) {
-        var warning = 'Unable to find lambda function ' + deploy_function + '. '
-        warning += 'Verify the lambda function name and AWS region are correct.'
-        gutil.log(warning);
-      } else {
-        var warning = 'AWS API request failed. '
-        warning += 'Check your AWS credentials and permissions.'
-        gutil.log(warning);
-      }
-    }
-
-    // This is a bit silly, simply because these five parameters are required.
-    var current = data.Configuration;
-    var params = {
-      FunctionName: functionName,
-      Handler: current.Handler,
-      Mode: current.Mode,
-      Role: current.Role,
-      Runtime: current.Runtime
-    };
-
-    fs.readFile('./dist.zip', function(err, data) {
-      params['FunctionZip'] = data;
-      lambda.uploadFunction(params, function(err, data) {
-        if (err) {
-          var warning = 'Package upload failed. '
-          warning += 'Check your iam:PassRole permissions.'
-          gutil.log(warning);
-        }
-      });
-    });
-  });
-});
-
 // The key to deploying as a single command is to manage the sequence of events.
 gulp.task('dist', function(cb) {
   return runSequence(

--- a/src/configuration/Region.json
+++ b/src/configuration/Region.json
@@ -1,3 +1,3 @@
 {
-  "Region": "us-east-1"
+  "Region": "ap-southeast-2"
 }


### PR DESCRIPTION
This is currently not an automated continuous deployment process. It needs to be run adhoc from developer box. 

- Region.json now has ap-southeast-2 json, but for production and uat we need to change it ad-hoc fashion.  

- An unused gulp block has been removed. 

- I have created an empty file config.env.production on my local box to eliminate lambda invocation errors. This file is filtered out by .gitignore. So you can't review it.
