### PR TITLE
Adding support for autoscaling based on a table tag as well as custom per-table config.

### DIFF
--- a/flow/aws-sdk.js
+++ b/flow/aws-sdk.js
@@ -62,6 +62,16 @@ declare module 'aws-sdk' {
      TableNames: string[]
   };
 
+  declare type ListTagsRequest = {
+     NextToken?: string,
+     ResourceArn?: string
+  };
+
+  declare type ListTagsResponse = {
+     NextToken?: string,
+     Tags: string[]
+  };
+
   declare type DeleteTableRequest = {
      TableName: string,
   };

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -6,6 +6,7 @@ import Throughput from './utils/Throughput';
 import ProvisionerLogging from './provisioning/ProvisionerLogging';
 import { Region } from './configuration/Region';
 import DefaultProvisioner from './configuration/DefaultProvisioner';
+import CustomProvisioners from './configuration/CustomProvisioners';
 import { invariant } from './Global';
 import type { TableProvisionedAndConsumedThroughput, ProvisionerConfig, AdjustmentContext } from './flow/FlowTypes';
 
@@ -34,22 +35,16 @@ export default class Provisioner extends ProvisionerConfigurableBase {
   getTableConfig(data: TableProvisionedAndConsumedThroughput): ProvisionerConfig {
 
     // Option 1 - Default settings for all tables
-    return DefaultProvisioner;
+    // return DefaultProvisioner;
 
     // Option 2 - Bespoke table specific settings
     // return data.TableName === 'Table1' ? Climbing : Default;
 
     // Option 3 - DynamoDB / S3 sourced table specific settings
     // return await ...;
-    
-    // Option 4 - Modify certain defaults with env vars
-    DefaultProvisioner.ReadCapacity.Min = process.env.AWS_MIN_READ || 5;
-    DefaultProvisioner.ReadCapacity.Max = process.env.AWS_MIN_WRITE || 100;
-    DefaultProvisioner.WriteCapacity.Min = process.env.AWS_MIN_WRITE || 1;
-    DefaultProvisioner.WriteCapacity.Max = process.env.AWS_MIN_WRITE || 100;
-   
-    console.log(DefaultProvisioner);
-    return DefaultProvisioner;
+
+    // Option 4 - Get the table specific config based on table name
+    return CustomProvisioners[data.TableName] || DefaultProvisioner;
   }
 
   isReadCapacityIncrementRequired(data: TableProvisionedAndConsumedThroughput): boolean {

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -66,17 +66,14 @@ export default class Provisioner extends ProvisionerConfigurableBase {
   // eslint-disable-next-line no-unused-vars
   getTableConfig(data: TableProvisionedAndConsumedThroughput): ProvisionerConfig {
 
-    // Option 1 - Default settings for all tables
-    // return DefaultProvisioner;
+    // Option 1 - Default settings for all tables unless included in CustomProvisioners.json
+    return (CustomProvisioners || {})[data.TableName] || DefaultProvisioner;
 
     // Option 2 - Bespoke table specific settings
     // return data.TableName === 'Table1' ? Climbing : Default;
 
     // Option 3 - DynamoDB / S3 sourced table specific settings
     // return await ...;
-
-    // Option 4 - Get the table specific config based on table name
-    return CustomProvisioners[data.TableName] || DefaultProvisioner;
   }
 
   isReadCapacityIncrementRequired(data: TableProvisionedAndConsumedThroughput): boolean {

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -22,7 +22,7 @@ export default class Provisioner extends ProvisionerConfigurableBase {
 
     // Option 1: Identify tables by custom tag
     if (process.env.DDB_AUTOSCALE_USE_TAGS) {
-      if (!process.env.AWS_REGION || !process.env.AWS_ACCOUNT_NUMBER || !process.env.AWS_AUTOSCALE_TAG_NAME) {
+      if (!process.env.AWS_REGION || !process.env.AWS_ACCOUNT_NUMBER || !process.env.DDB_AUTOSCALE_TAG_NAME) {
         throw new Error('Missing environemnt variables to build the AWS ARN');
       }
 
@@ -43,7 +43,7 @@ export default class Provisioner extends ProvisionerConfigurableBase {
         })
         .then(tableNamesWithTags => {
           return tableNamesWithTags
-            .filter(pkg => { return pkg.tags.some(tag => tag.Key === process.env.AWS_AUTOSCALE_TAG_NAME || 'autoscaled' && tag.Value.match(/true/g)); })
+            .filter(pkg => { return pkg.tags.some(tag => tag.Key === process.env.DDB_AUTOSCALE_TAG_NAME || 'autoscaled' && tag.Value.match(/true/g)); })
             .map(pkg => pkg.tableName);
         })
         .then(tableNames => {

--- a/src/Provisioner.js
+++ b/src/Provisioner.js
@@ -41,6 +41,15 @@ export default class Provisioner extends ProvisionerConfigurableBase {
 
     // Option 3 - DynamoDB / S3 sourced table specific settings
     // return await ...;
+    
+    // Option 4 - Modify certain defaults with env vars
+    DefaultProvisioner.ReadCapacity.Min = process.env.AWS_MIN_READ || 5;
+    DefaultProvisioner.ReadCapacity.Max = process.env.AWS_MIN_WRITE || 100;
+    DefaultProvisioner.WriteCapacity.Min = process.env.AWS_MIN_WRITE || 1;
+    DefaultProvisioner.WriteCapacity.Max = process.env.AWS_MIN_WRITE || 100;
+   
+    console.log(DefaultProvisioner);
+    return DefaultProvisioner;
   }
 
   isReadCapacityIncrementRequired(data: TableProvisionedAndConsumedThroughput): boolean {

--- a/src/provisioning/ProvisionerLogging.js
+++ b/src/provisioning/ProvisionerLogging.js
@@ -6,6 +6,10 @@ import type {
 } from '../flow/FlowTypes';
 
 export default class ConfigLogging {
+  static logIdentifiedTables(tableNames) {
+    log('The following tables were identified for autoscaling:', tableNames);
+  }
+
   static isAdjustmentRequiredLog(
     adjustmentContext: AdjustmentContext,
     adjustmentData: AdjustmentData,


### PR DESCRIPTION
I'd like to be able to autoscale tables based on some autoscaling tag put on the table. This PR allows the end user to either use the default `autoscaled` tag name or specify one through an environment variable :-).

In addition, I wanted to have a way to keep latency down but still have a way to have custom, moderately flexible, per-table configs. I included the idea of a `CustomProvisioners` file where you could map the keys to the table name you want the config to apply to and have the value for those keys just be a specific version of the default config.

Ie:
```
{
  table_name_1: {
    ReadCapacity: { Min: 5, Max: 100 ...},
    WriteCapacity: { Min: 1, Max: 50 ...}.
  ...
  },
  table_name_2: { ... }
}
```

I'm quite new to dynamo and this autoscaler project in general so any feedback is always appreciated. I tried to design this in a way that would still be backwards compatible to all current defaults.